### PR TITLE
removed msi token and added structure version

### DIFF
--- a/AttestationClientApp.cpp
+++ b/AttestationClientApp.cpp
@@ -38,7 +38,7 @@ public:
 };
 
 // Attestation tenant URI + Guest attestation path + API version
-std::string attestation_url = "https://sharedeus.eus.test.attest.azure.net/attest/Tee/AzureGuest?api-version=2018-09-01-preview";
+std::string attestation_url = "https://sharedeus.eus.test.attest.azure.net/attest/AzureGuest?api-version=2020-10-01";
 
 int main() {
     try {
@@ -53,13 +53,13 @@ int main() {
             exit(1);
         }
 
-        // Get the MSI token by calling IMDS
-        std::string msi_token = GetMSI();
+        // parameters for the Attest call       
         attest::ClientParameters params = {};
-        params.authentication_token = (unsigned char*) msi_token.c_str();
         params.attestation_endpoint_url = (unsigned char*) attestation_url.c_str();
         std::string client_payload_str = "{\"nonce\":\"1234\"}";
         params.client_payload = (unsigned char*) client_payload_str.c_str();
+        // structure version
+        params.version = CLIENT_PARAMS_VERSION;
         unsigned char* jwt = nullptr;
         attest::AttestationResult result;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57220065/176639560-03ffd8b4-3477-4c17-a748-d73c76f35f50.png)

Removed MSI and added version for ClientParameters structure.
AttestationClientApp.exe runs successfully.